### PR TITLE
Optimization and Support for more format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+This is the changelog/release notes for `Pyaccelsx`.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2024-09-06
+
+### Added
+
+- Added formatting support for `bg_color`.
+- Added a writer handler for `None` and `bool` values.
+- Added class and function docs.
+
+### Changed
+
+- Use `write_string` and `write_string_with_format` to write strings.
+- Use index when getting a worksheet instead of name.
+
+### Fixed
+
+- Fixed `Format` object always getting created when writing numbers.
+
+### Removed
+
+- Removed unused files.
+
+## [0.2.0] - 2024-09-04
+
+### Added
+
+- Added formatting support for the following format options: `bold`, `underline`, `alignment`, `font_color`, `border`, `num_format`.
+- Added support for writing string and numbers.
+- Added support for merging cell range.
+- Added support for merging cells and write into the merged cells (numbers and strings).
+- Added support for setting column width.
+- Added support for freeze panes.
+
+### Fixed
+
+- Fixed the structure of files.
+
+## [0.1.0] - 2024-09-04
+
+### Added
+
+- Initial version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 This is the changelog/release notes for `Pyaccelsx`.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.2.0] - 2024-09-06
+## [0.2.1] - 2024-09-06
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added formatting support for `bg_color`.
 - Added a writer handler for `None` and `bool` values.
 - Added class and function docs.
+- Categorize writers into a single module.
 
 ### Changed
 
+- Use one single function to write for multiple types (`str`, `int`, `float`, `bool`, and `None`).
 - Use `write_string` and `write_string_with_format` to write strings.
 - Use index when getting a worksheet instead of name.
+- Make rows and columns to follow the correct type from `rust_xlsxwriter`.
 
 ### Fixed
 
 - Fixed `Format` object always getting created when writing numbers.
+- Enabled `ExcelFormat` to be cloned.
+- Removed redundant functions.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog/release notes for `Pyaccelsx`.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.2.1] - 2024-09-06
+## [0.2.1] - 2024-09-08
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "pyaccelsx"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "pyo3",
  "rust_xlsxwriter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyaccelsx"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ merge_format = ExcelFormat(
 )
 
 # Write some data to the worksheet
-workbook.write(0, 0, "Hello", bold_format)
-workbook.write(0, 1, 44123.456, numeric_format)
-workbook.write(0, 2, "Right", right_aligned_format)
-workbook.write(0, 3, "Color", color_format)
-workbook.write_and_merge_range(1, 0, 1, 3, "Merge", merge_format)
-workbook.write_and_merge_range(2, 0, 2, 3, 123456, merge_format)
-workbook.write(3, 1, "border", border_format)
+workbook.write(0, 0, "Hello", format_option=bold_format)
+workbook.write(0, 1, 44123.456, format_option=numeric_format)
+workbook.write(0, 2, "Right", format_option=right_aligned_format)
+workbook.write(0, 3, "Color", format_option=color_format)
+workbook.write_and_merge_range(1, 0, 1, 3, "Merge", format_option=merge_format)
+workbook.write_and_merge_range(2, 0, 2, 3, 123456, format_option=merge_format)
+workbook.write(3, 1, "border", format_option=border_format)
 
 # Save the workbook
 workbook.save("example.xlsx")

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ merge_format = ExcelFormat(
 )
 
 # Write some data to the worksheet
-workbook.write_string(0, 0, "Hello", bold_format)
-workbook.write_number(0, 1, 44123.456, numeric_format)
-workbook.write_string(0, 2, "Right", right_aligned_format)
-workbook.write_string(0, 3, "Color", color_format)
-workbook.write_string_and_merge_range(1, 0, 1, 3, "Merge", merge_format)
-workbook.write_number_and_merge_range(2, 0, 2, 3, 123456, merge_format)
-workbook.write_string(3, 1, "border", border_format)
+workbook.write(0, 0, "Hello", bold_format)
+workbook.write(0, 1, 44123.456, numeric_format)
+workbook.write(0, 2, "Right", right_aligned_format)
+workbook.write(0, 3, "Color", color_format)
+workbook.write_and_merge_range(1, 0, 1, 3, "Merge", merge_format)
+workbook.write_and_merge_range(2, 0, 2, 3, 123456, merge_format)
+workbook.write(3, 1, "border", border_format)
 
 # Save the workbook
 workbook.save("example.xlsx")

--- a/src/format.rs
+++ b/src/format.rs
@@ -7,6 +7,7 @@ use rust_xlsxwriter::{Format, FormatAlign, FormatBorder, FormatUnderline};
 #[derive(FromPyObject)]
 pub struct ExcelFormat {
     align: Option<String>,
+    bg_color: Option<String>,
     bold: Option<bool>,
     border: Option<bool>,
     border_top: Option<bool>,
@@ -23,6 +24,7 @@ impl ExcelFormat {
     #[new]
     #[pyo3(signature = (
         align=None,
+        bg_color=None,
         bold=None,
         border=None,
         border_top=None,
@@ -35,6 +37,7 @@ impl ExcelFormat {
     ))]
     pub fn new(
         align: Option<String>,
+        bg_color: Option<String>,
         bold: Option<bool>,
         border: Option<bool>,
         border_top: Option<bool>,
@@ -47,6 +50,7 @@ impl ExcelFormat {
     ) -> ExcelFormat {
         ExcelFormat {
             align,
+            bg_color,
             bold,
             border,
             border_top,
@@ -81,28 +85,32 @@ pub fn create_format(format_option: ExcelFormat) -> Format {
         })
     }
 
+    if let Some(bg_color) = format_option.bg_color {
+        format = format.set_background_color(bg_color.as_str());
+    }
+
     if format_option.bold.unwrap_or(false) {
         format = format.set_bold();
     }
 
     if format_option.border.unwrap_or(false) {
         format = format.set_border(FormatBorder::Thin);
-    }
+    } else {
+        if format_option.border_top.unwrap_or(false) {
+            format = format.set_border_top(FormatBorder::Thin);
+        }
 
-    if format_option.border_top.unwrap_or(false) {
-        format = format.set_border_top(FormatBorder::Thin);
-    }
+        if format_option.border_bottom.unwrap_or(false) {
+            format = format.set_border_bottom(FormatBorder::Thin);
+        }
 
-    if format_option.border_bottom.unwrap_or(false) {
-        format = format.set_border_bottom(FormatBorder::Thin);
-    }
+        if format_option.border_left.unwrap_or(false) {
+            format = format.set_border_left(FormatBorder::Thin);
+        }
 
-    if format_option.border_left.unwrap_or(false) {
-        format = format.set_border_left(FormatBorder::Thin);
-    }
-
-    if format_option.border_right.unwrap_or(false) {
-        format = format.set_border_right(FormatBorder::Thin);
+        if format_option.border_right.unwrap_or(false) {
+            format = format.set_border_right(FormatBorder::Thin);
+        }
     }
 
     if let Some(color) = format_option.font_color {

--- a/src/format.rs
+++ b/src/format.rs
@@ -26,7 +26,7 @@ use rust_xlsxwriter::{Format, FormatAlign, FormatBorder, FormatUnderline};
 ///     workbook.save("example.xlsx")
 /// ```
 #[pyclass(get_all, set_all)]
-#[derive(FromPyObject)]
+#[derive(Clone)]
 pub struct ExcelFormat {
     align: Option<String>,
     bg_color: Option<String>,

--- a/src/format.rs
+++ b/src/format.rs
@@ -2,7 +2,29 @@
 use pyo3::prelude::*;
 use rust_xlsxwriter::{Format, FormatAlign, FormatBorder, FormatUnderline};
 
-/// Format options passed from Python
+/// The `ExcelFormat` contains the format options passed from Python
+/// to Rust, and used to create a custom `Format` object depending on
+/// the configured format options.
+///
+/// ## Examples
+/// The following example demonstrates creating a `rust_xlsxwriter::Format` object.
+/// ```
+/// from pyaccelsx import ExcelWorkbook, ExcelFormat
+///
+/// def main():
+///     workbook = ExcelWorkbook()
+///     workbook.add_worksheet()
+///
+///     format_option = ExcelFormat(
+///         align="center",
+///         bg_color="FFFF00",
+///         bold=True,
+///     )
+///
+///     workbook.write_string(0, 0, "Hello World!", format_option)
+///
+///     workbook.save("example.xlsx")
+/// ```
 #[pyclass(get_all, set_all)]
 #[derive(FromPyObject)]
 pub struct ExcelFormat {
@@ -64,6 +86,14 @@ impl ExcelFormat {
     }
 }
 
+/// Creates a `rust_xlsxwriter::Format` object from the `ExcelFormat`
+/// options passed from Python.
+///
+/// ## Parameters
+/// - `format_option`: The format options passed from Python
+///
+/// ## Returns
+/// - A `rust_xlsxwriter::Format` object
 pub fn create_format(format_option: ExcelFormat) -> Format {
     let mut format = Format::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod format;
+pub mod util;
 pub mod workbook;
+pub mod writer;
 
 use format::ExcelFormat;
 use pyo3::prelude::*;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,13 @@
+use pyo3::prelude::*;
+
+#[derive(FromPyObject)]
+pub enum ValueType {
+    #[pyo3(transparent, annotation = "str")]
+    String(String),
+    #[pyo3(transparent, annotation = "bool")]
+    Bool(bool),
+    #[pyo3(transparent, annotation = "int")]
+    Int(f64),
+    #[pyo3(transparent, annotation = "float")]
+    Float(f64),
+}

--- a/src/value_type.rs
+++ b/src/value_type.rs
@@ -1,7 +1,0 @@
-pub enum ValueType<T> {
-    String(T),
-    Float(T),
-    Int(T),
-    Bool(T),
-    None,
-}

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -25,7 +25,10 @@ impl ExcelWorkbook {
         if name.is_none() {
             self.workbook.add_worksheet();
         } else {
-            self.workbook.add_worksheet().set_name(name.unwrap()).unwrap();
+            self.workbook
+                .add_worksheet()
+                .set_name(name.unwrap())
+                .unwrap();
         }
         self.active_worksheet_index = self.workbook.worksheets().len() - 1;
     }
@@ -39,7 +42,8 @@ impl ExcelWorkbook {
     pub fn write_blank(&mut self, row: u32, column: u16, format_option: Option<ExcelFormat>) {
         let worksheet = self
             .workbook
-            .worksheet_from_index(self.active_worksheet_index).unwrap();
+            .worksheet_from_index(self.active_worksheet_index)
+            .unwrap();
         if format_option.is_none() {
             worksheet.write(row, column, "").unwrap();
         } else {
@@ -60,7 +64,8 @@ impl ExcelWorkbook {
     ) {
         let worksheet = self
             .workbook
-            .worksheet_from_index(self.active_worksheet_index).unwrap();
+            .worksheet_from_index(self.active_worksheet_index)
+            .unwrap();
         if format_option.is_none() {
             worksheet.write(row, column, value).unwrap();
         } else {
@@ -81,11 +86,10 @@ impl ExcelWorkbook {
     ) {
         let worksheet = self
             .workbook
-            .worksheet_from_index(self.active_worksheet_index).unwrap();
+            .worksheet_from_index(self.active_worksheet_index)
+            .unwrap();
         if format_option.is_none() {
-            worksheet
-                .write_number(row, column, value)
-                .unwrap();
+            worksheet.write_number(row, column, value).unwrap();
         } else {
             let format = format::create_format(format_option.unwrap());
             worksheet
@@ -105,7 +109,8 @@ impl ExcelWorkbook {
     ) {
         let worksheet = self
             .workbook
-            .worksheet_from_index(self.active_worksheet_index).unwrap();
+            .worksheet_from_index(self.active_worksheet_index)
+            .unwrap();
         if format_option.is_none() {
             worksheet
                 .merge_range(
@@ -137,7 +142,8 @@ impl ExcelWorkbook {
     ) {
         let worksheet = self
             .workbook
-            .worksheet_from_index(self.active_worksheet_index).unwrap();
+            .worksheet_from_index(self.active_worksheet_index)
+            .unwrap();
         if format_option.is_none() {
             worksheet
                 .merge_range(
@@ -169,7 +175,8 @@ impl ExcelWorkbook {
     ) {
         let worksheet = self
             .workbook
-            .worksheet_from_index(self.active_worksheet_index).unwrap();
+            .worksheet_from_index(self.active_worksheet_index)
+            .unwrap();
         if format_option.is_none() {
             worksheet
                 .merge_range(
@@ -198,14 +205,16 @@ impl ExcelWorkbook {
     pub fn set_column_width(&mut self, column: u16, width: u16) {
         let worksheet = self
             .workbook
-            .worksheet_from_index(self.active_worksheet_index).unwrap();
+            .worksheet_from_index(self.active_worksheet_index)
+            .unwrap();
         worksheet.set_column_width(column, width).unwrap();
     }
 
     pub fn freeze_panes(&mut self, row: u32, column: u16) {
         let worksheet = self
             .workbook
-            .worksheet_from_index(self.active_worksheet_index).unwrap();
+            .worksheet_from_index(self.active_worksheet_index)
+            .unwrap();
         worksheet.set_freeze_panes(row, column).unwrap();
     }
 }

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -3,6 +3,10 @@ use pyo3::prelude::*;
 use rust_xlsxwriter::{Format, Workbook};
 
 #[pyclass]
+/// The `ExcelWorkbook` struct represents an Excel workbook.
+/// This contains the workbook object and the active worksheet index.
+/// Worksheet methods are directly implemented under this class,
+/// as they are mutable references in which the ownership cannot be transferred.
 pub struct ExcelWorkbook {
     workbook: Workbook,
     active_worksheet_index: usize,
@@ -11,6 +15,17 @@ pub struct ExcelWorkbook {
 #[pymethods]
 impl ExcelWorkbook {
     #[new]
+    /// Create a new workbook.
+    /// ## Examples
+    /// The following example demonstrates creating a simple workbook, with one unused worksheet.
+    /// ```
+    /// from pyaccelsx import ExcelWorkbook
+    ///
+    /// def main():
+    ///     workbook = ExcelWorkbook()
+    ///     workbook.add_worksheet()
+    ///     workbook.save("example.xlsx")
+    /// ```
     pub fn new() -> ExcelWorkbook {
         let workbook = Workbook::new();
         ExcelWorkbook {
@@ -21,7 +36,33 @@ impl ExcelWorkbook {
 
     /// Add a new worksheet to the workbook and update the active worksheet index.
     #[pyo3(signature = (name=None))]
-    pub fn add_worksheet(&mut self, name: Option<&str>) {
+    /// Adds a new worksheet to the workbook with the given sheet name.
+    /// If no name is given, the standard names (`Sheet1`, `Sheet2`, etc.) will be used.
+    ///
+    /// Pyaccelsx used `active_worksheet_index` to keep track of the active worksheet.
+    /// Adding a new worksheet into the workbook will automatically increment `active_worksheet_index`.
+    ///
+    /// ## Parameters
+    /// - `name`: The name of the new worksheet _(optional)_
+    ///
+    /// ## Examples
+    /// The following example demonstrates adding worksheets to a workbook.
+    /// ```
+    /// from pyaccelsx import ExcelWorkbook
+    ///
+    /// def main():
+    ///     workbook = ExcelWorkbook()
+    ///
+    ///     workbook.add_worksheet()    // Sheet1
+    ///     workbook.add_worksheet("My Sheet")
+    ///     workbook.add_worksheet()    // Sheet3
+    ///
+    ///     // This is written in Sheet3
+    ///     workbook..write_string(0, 0, "Hello")
+    ///     
+    ///     workbook.save("example.xlsx")
+    /// ```
+    pub fn add_worksheet(&mut self, name: Option<&str>) -> PyResult<()> {
         if name.is_none() {
             self.workbook.add_worksheet();
         } else {
@@ -31,17 +72,64 @@ impl ExcelWorkbook {
                 .unwrap();
         }
         self.active_worksheet_index = self.workbook.worksheets().len() - 1;
+        Ok(())
     }
 
     /// Save the workbook into the specified path.
-    pub fn save(&mut self, path: &str) {
+    ///
+    /// ## Parameters
+    /// - `path`: The path to save the workbook
+    ///
+    /// ## Examples
+    /// The following example demonstrates saving a workbook.
+    /// ```
+    /// from pyaccelsx import ExcelWorkbook
+    ///
+    /// def main():
+    ///     workbook = ExcelWorkbook()
+    ///     workbook.add_worksheet()
+    ///     workbook.save("example.xlsx")
+    /// ```
+    pub fn save(&mut self, path: &str) -> PyResult<()> {
         self.workbook.save(path).unwrap();
+        Ok(())
     }
 
     #[pyo3(signature = (row, column, format_option=None))]
-    pub fn write_blank(&mut self, row: u32, column: u16, format_option: Option<ExcelFormat>) {
-        // Only write a "blank" cell if there is a format option.
-        // If there is no format option, the corresponding cell will be an "empty" cell.
+    /// Worksheet handler for writing a "blank" cell.
+    /// This function will only perform write if `format_option` is specified.
+    /// If there is no format option specified, the corresponding cell will be an "empty" cell.
+    ///
+    /// See this [documentation](https://docs.rs/rust_xlsxwriter/0.75.0/rust_xlsxwriter/worksheet/struct.Worksheet.html#method.write_blank) for difference between "blank cell" and "empty cell".
+    ///
+    /// ## Parameters
+    /// - `row`: The row index of the cell
+    /// - `column`: The column index of the cell
+    /// - `format_option`: The format of the cell _(optional)_
+    ///
+    /// ## Examples
+    /// The following example demonstrates writing a "blank" cell to a worksheet.
+    /// ```
+    /// from pyaccelsx import ExcelWorkbook, ExcelFormat
+    ///
+    /// def main():
+    ///     workbook = ExcelWorkbook()
+    ///     workbook.add_worksheet()
+    ///     
+    ///     format_option = ExcelFormat(border=True)
+    ///     workbook.write_blank(0, 0, format_option)
+    ///     // This will not perform any write
+    ///     workbook.write_blank(0, 1)
+    ///
+    ///     workbook.save("example.xlsx")
+    /// ```
+    ///
+    pub fn write_blank(
+        &mut self,
+        row: u32,
+        column: u16,
+        format_option: Option<ExcelFormat>,
+    ) -> PyResult<()> {
         if let Some(format_option) = format_option {
             let worksheet = self
                 .workbook
@@ -50,27 +138,52 @@ impl ExcelWorkbook {
             let format = format::create_format(format_option);
             worksheet.write_blank(row, column, &format).unwrap();
         }
+        Ok(())
     }
 
     #[pyo3(signature = (row, column, override_value=None, format_option=None))]
+    /// Worksheet handler for writing `None` values.
+    ///
+    /// ## Parameters
+    /// - `row`: The row index of the cell
+    /// - `column`: The column index of the cell
+    /// - `override_value`: The string value to write if cell value is None _(optional)_
+    /// - `format_option`: The format of the cell _(optional)_
+    ///
+    /// ## Examples
+    /// The following example demonstrates writing a `None` value to a worksheet.
+    /// ```
+    /// from pyaccelsx import ExcelWorkbook, ExcelFormat
+    ///
+    /// def main():
+    ///     workbook = ExcelWorkbook()
+    ///     workbook.add_worksheet()
+    ///
+    ///     // This will write "N/A" for `None` values
+    ///     workbook.write_null(0, 0, "N/A")
+    ///     // This will not perform any write    
+    ///     workbook.write_null(0, 1)
+    ///     // This will perform `write_blank`
+    ///     format_option = ExcelFormat(align="right")
+    ///     workbook.write_null(row=0, column=2, format_option=format_option)
+    ///
+    ///     workbook.save("example.xlsx")
+    /// ```
     pub fn write_null(
         &mut self,
         row: u32,
         column: u16,
         override_value: Option<&str>,
         format_option: Option<ExcelFormat>,
-    ) {
+    ) -> PyResult<()> {
         let worksheet = self
             .workbook
             .worksheet_from_index(self.active_worksheet_index)
             .unwrap();
         if format_option.is_none() {
-            match override_value {
-                Some(override_value) => {
-                    worksheet.write_string(row, column, override_value).unwrap()
-                }
-                None => worksheet.write_string(row, column, "").unwrap(),
-            };
+            if let Some(override_value) = override_value {
+                worksheet.write_string(row, column, override_value).unwrap();
+            }
         } else {
             let format = format::create_format(format_option.unwrap());
             match override_value {
@@ -80,16 +193,40 @@ impl ExcelWorkbook {
                 None => worksheet.write_blank(row, column, &format).unwrap(),
             };
         }
+        Ok(())
     }
 
     #[pyo3(signature = (row, column, value, format_option=None))]
+    /// Worksheet handler for writing string values.
+    ///
+    /// ## Parameters
+    /// - `row`: The row index of the cell
+    /// - `column`: The column index of the cell
+    /// - `value`: The string value to write
+    /// - `format_option`: The format of the cell _(optional)_
+    ///
+    /// ## Examples
+    /// The following example demonstrates writing a string to a worksheet.
+    /// ```
+    /// from pyaccelsx import ExcelWorkbook, ExcelFormat
+    ///
+    /// def main():
+    ///     workbook = ExcelWorkbook()
+    ///     workbook.add_worksheet()
+    ///
+    ///     workbook.write_string(0, 0, "Hello")
+    ///     format_option = ExcelFormat(bold=True)
+    ///     workbook.write_string(0, 1, "World!", format_option)
+    ///
+    ///     workbook.save("example.xlsx")
+    /// ```
     pub fn write_string(
         &mut self,
         row: u32,
         column: u16,
         value: &str,
         format_option: Option<ExcelFormat>,
-    ) {
+    ) -> PyResult<()> {
         let worksheet = self
             .workbook
             .worksheet_from_index(self.active_worksheet_index)
@@ -102,16 +239,45 @@ impl ExcelWorkbook {
                 .write_string_with_format(row, column, value, &format)
                 .unwrap();
         }
+        Ok(())
     }
 
     #[pyo3(signature = (row, column, value, format_option=None))]
+    /// Worksheet handler for writing numeric values. By default, values
+    /// are passed as a float (`f64`) type. To specify whether to write intenger
+    /// or float, use the `format_option` and set the `num_format` field.
+    ///
+    /// ## Parameters
+    /// - `row`: The row index of the cell
+    /// - `column`: The column index of the cell
+    /// - `value`: The numeric value to write
+    /// - `format_option`: The format of the cell _(optional)_
+    ///
+    /// ## Examples
+    /// The following example demonstrates writing numeric values to a worksheet.
+    /// ```
+    /// from pyaccelsx import ExcelWorkbook, ExcelFormat
+    ///
+    /// def main():
+    ///     workbook = ExcelWorkbook()
+    ///     workbook.add_worksheet()
+    ///     
+    ///     // This will be written to cell as float (123445.21)
+    ///     format_option = ExcelFormat(num_format="#,##0.00")
+    ///     workbook.write_number(0, 0, 123445.21, format_option)
+    ///     // This will be written to cell as integer (123,456)
+    ///     format_option = ExcelFormat(num_format="#,##0")
+    ///     workbook.write_number(0, 1, 123456, format_option)
+    ///
+    ///     workbook.save("example.xlsx")
+    /// ```
     pub fn write_number(
         &mut self,
         row: u32,
         column: u16,
         value: f64,
         format_option: Option<ExcelFormat>,
-    ) {
+    ) -> PyResult<()> {
         let worksheet = self
             .workbook
             .worksheet_from_index(self.active_worksheet_index)
@@ -124,9 +290,39 @@ impl ExcelWorkbook {
                 .write_number_with_format(row, column, value, &format)
                 .unwrap();
         }
+        Ok(())
     }
 
     #[pyo3(signature = (row, column, value, override_value=None, format_option=None))]
+    /// Worksheet handler for writing boolean values. By default, values
+    /// are written as `True` or `False`. To specify an override string value
+    /// to replace the boolean values, use the `override_value` field.
+    ///
+    /// ## Parameters
+    /// - `row`: The row index of the cell
+    /// - `column`: The column index of the cell
+    /// - `value`: The boolean value to write
+    /// - `override_value`: The string value to override inplace of `True` or `False` _(optional)_
+    /// - `format_option`: The format of the cell _(optional)_
+    ///
+    /// ## Examples
+    /// The following example demonstrates writing boolean values to a worksheet.
+    /// ```
+    /// from pyaccelsx import ExcelWorkbook
+    ///
+    /// def main():
+    ///     workbook = ExcelWorkbook()
+    ///     workbook.add_worksheet()
+    ///     
+    ///     // This will be written to cell as True
+    ///     workbook.write_boolean(0, 0, True)
+    ///     // This will be written to cell as False
+    ///     workbook.write_boolean(0, 1, False)
+    ///     // This will be written to cell as override value
+    ///     workbook.write_boolean(0, 2, False, "No")
+    ///
+    ///     workbook.save("example.xlsx")
+    /// ```
     pub fn write_boolean(
         &mut self,
         row: u32,
@@ -134,7 +330,7 @@ impl ExcelWorkbook {
         value: bool,
         override_value: Option<&str>,
         format_option: Option<ExcelFormat>,
-    ) {
+    ) -> PyResult<()> {
         let worksheet = self
             .workbook
             .worksheet_from_index(self.active_worksheet_index)
@@ -157,9 +353,35 @@ impl ExcelWorkbook {
                     .unwrap(),
             };
         }
+        Ok(())
     }
 
     #[pyo3(signature = (start_row, start_column, end_row, end_column, format_option=None))]
+    /// Worksheet handler for merging a range of cells. This will not do any
+    /// writing to the cell values. To write values, use either
+    /// `write_string_and_merge_range` or `write_number_and_merge_range`.
+    ///
+    /// ## Parameters
+    /// - `start_row`: The start row index of the range
+    /// - `start_column`: The start column index of the range
+    /// - `end_row`: The end row index of the range
+    /// - `end_column`: The end column index of the range
+    /// - `format_option`: The format of the cell _(optional)_
+    ///
+    /// ## Examples
+    /// The following example demonstrates merging cells in a worksheet.
+    /// ```
+    /// from pyaccelsx import ExcelWorkbook, ExcelFormat
+    ///
+    /// def main():
+    ///     workbook = ExcelWorkbook()
+    ///     workbook.add_worksheet()
+    ///     
+    ///     format_option = ExcelFormat(align="center", border=True)
+    ///     workbook.merge_range(0, 0, 0, 2, format_option)
+    ///
+    ///     workbook.save("example.xlsx")
+    /// ```
     pub fn merge_range(
         &mut self,
         start_row: u32,
@@ -167,7 +389,7 @@ impl ExcelWorkbook {
         end_row: u32,
         end_column: u16,
         format_option: Option<ExcelFormat>,
-    ) {
+    ) -> PyResult<()> {
         let worksheet = self
             .workbook
             .worksheet_from_index(self.active_worksheet_index)
@@ -189,9 +411,34 @@ impl ExcelWorkbook {
                 .merge_range(start_row, start_column, end_row, end_column, "", &format)
                 .unwrap();
         }
+        Ok(())
     }
 
     #[pyo3(signature = (start_row, start_column, end_row, end_column, value, format_option=None))]
+    /// Worksheet handler for merging a range of cells and writing string value into the merged cells.
+    ///
+    /// ## Parameters
+    /// - `start_row`: The start row index of the range
+    /// - `start_column`: The start column index of the range
+    /// - `end_row`: The end row index of the range
+    /// - `end_column`: The end column index of the range
+    /// - `value`: The string value to write
+    /// - `format_option`: The format of the cell _(optional)_
+    ///
+    /// ## Examples
+    /// The following example demonstrates merging cells and writing string value into the merged cells in a worksheet.
+    /// ```
+    /// from pyaccelsx import ExcelWorkbook, ExcelFormat
+    ///
+    /// def main():
+    ///     workbook = ExcelWorkbook()
+    ///     workbook.add_worksheet()
+    ///     
+    ///     format_option = ExcelFormat(align="center", border=True)
+    ///     workbook.write_string_and_merge_range(0, 0, 0, 2, "Hello World!", format_option)
+    ///
+    ///     workbook.save("example.xlsx")
+    /// ```
     pub fn write_string_and_merge_range(
         &mut self,
         start_row: u32,
@@ -200,7 +447,7 @@ impl ExcelWorkbook {
         end_column: u16,
         value: &str,
         format_option: Option<ExcelFormat>,
-    ) {
+    ) -> PyResult<()> {
         let worksheet = self
             .workbook
             .worksheet_from_index(self.active_worksheet_index)
@@ -222,9 +469,36 @@ impl ExcelWorkbook {
                 .merge_range(start_row, start_column, end_row, end_column, value, &format)
                 .unwrap();
         }
+        Ok(())
     }
 
     #[pyo3(signature = (start_row, start_column, end_row, end_column, value, format_option=None))]
+    /// Worksheet handler for merging a range of cells and writing numeric values into the merged cells.
+    /// By default, values are passed as a float (`f64`) type. To specify whether to write intenger
+    /// or float, use the `format_option` and set the `num_format` field.
+    ///
+    /// ## Parameters
+    /// - `start_row`: The start row index of the range
+    /// - `start_column`: The start column index of the range
+    /// - `end_row`: The end row index of the range
+    /// - `end_column`: The end column index of the range
+    /// - `value`: The string value to write
+    /// - `format_option`: The format of the cell _(optional)_
+    ///
+    /// ## Examples
+    /// The following example demonstrates merging cells and writing numeric value into the merged cells in a worksheet.
+    /// ```
+    /// from pyaccelsx import ExcelWorkbook, ExcelFormat
+    ///
+    /// def main():
+    ///     workbook = ExcelWorkbook()
+    ///     workbook.add_worksheet()
+    ///     
+    ///     format_option = ExcelFormat(align="center", border=True, num_format="#,##0.00")
+    ///     workbook.write_number_and_merge_range(0, 0, 0, 2, 12.45, format_option)
+    ///
+    ///     workbook.save("example.xlsx")
+    /// ```
     pub fn write_number_and_merge_range(
         &mut self,
         start_row: u32,
@@ -233,7 +507,7 @@ impl ExcelWorkbook {
         end_column: u16,
         value: f64,
         format_option: Option<ExcelFormat>,
-    ) {
+    ) -> PyResult<()> {
         let worksheet = self
             .workbook
             .worksheet_from_index(self.active_worksheet_index)
@@ -261,22 +535,66 @@ impl ExcelWorkbook {
                 .write_number_with_format(start_row, start_column, value, &format)
                 .unwrap();
         }
+        Ok(())
     }
 
-    pub fn set_column_width(&mut self, column: u16, width: u16) {
+    /// Worksheet handler for setting column width.
+    ///
+    /// ## Parameters
+    /// - `column`: The column index of the cell
+    /// - `width`: The width of the column
+    ///
+    /// ## Examples
+    /// The following example demonstrates setting column width in a worksheet.
+    /// ```
+    /// from pyaccelsx import ExcelWorkbook
+    ///
+    /// def main():
+    ///     workbook = ExcelWorkbook()
+    ///     workbook.add_worksheet()
+    ///
+    ///     workbook.write_string(0, 0, "Hello World!")
+    ///     workbook.set_column_width(0, 20)
+    ///
+    ///     workbook.save("example.xlsx")
+    /// ```
+    pub fn set_column_width(&mut self, column: u16, width: u16) -> PyResult<()> {
         let worksheet = self
             .workbook
             .worksheet_from_index(self.active_worksheet_index)
             .unwrap();
         worksheet.set_column_width(column, width).unwrap();
+        Ok(())
     }
 
-    pub fn freeze_panes(&mut self, row: u32, column: u16) {
+    /// Worksheet handler for freezing panes.
+    ///
+    /// ## Parameters
+    /// - `row`: The row index of the cell which will be frozen
+    /// - `column`: The column index of the cell which will be frozen
+    ///
+    /// ## Examples
+    /// The following example demonstrates freezing panes in a worksheet.
+    /// ```
+    /// from pyaccelsx import ExcelWorkbook
+    ///
+    /// def main():
+    ///     workbook = ExcelWorkbook()
+    ///     workbook.add_worksheet()
+    ///
+    ///     workbook.write_string(0, 0, "Hello World!")
+    ///     // This freezes the first row and first column
+    ///     workbook.freeze_panes(0, 0)
+    ///
+    ///     workbook.save("example.xlsx")
+    /// ```
+    pub fn freeze_panes(&mut self, row: u32, column: u16) -> PyResult<()> {
         let worksheet = self
             .workbook
             .worksheet_from_index(self.active_worksheet_index)
             .unwrap();
         worksheet.set_freeze_panes(row, column).unwrap();
+        Ok(())
     }
 }
 

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -19,7 +19,7 @@ impl ExcelWorkbook {
         }
     }
 
-    /// Add a new worksheet to the workbook.
+    /// Add a new worksheet to the workbook and update the active worksheet index.
     #[pyo3(signature = (name=None))]
     pub fn add_worksheet(&mut self, name: Option<&str>) {
         if name.is_none() {
@@ -45,12 +45,10 @@ impl ExcelWorkbook {
             .worksheet_from_index(self.active_worksheet_index)
             .unwrap();
         if format_option.is_none() {
-            worksheet.write(row, column, "").unwrap();
+            worksheet.write_string(row, column, "").unwrap();
         } else {
             let format = format::create_format(format_option.unwrap());
-            worksheet
-                .write_with_format(row, column, "", &format)
-                .unwrap();
+            worksheet.write_blank(row, column, &format).unwrap();
         }
     }
 
@@ -67,11 +65,11 @@ impl ExcelWorkbook {
             .worksheet_from_index(self.active_worksheet_index)
             .unwrap();
         if format_option.is_none() {
-            worksheet.write(row, column, value).unwrap();
+            worksheet.write_string(row, column, value).unwrap();
         } else {
             let format = format::create_format(format_option.unwrap());
             worksheet
-                .write_with_format(row, column, value, &format)
+                .write_string_with_format(row, column, value, &format)
                 .unwrap();
         }
     }

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -391,7 +391,7 @@ impl ExcelWorkbook {
     ///
     ///     workbook.save("example.xlsx")
     /// ```
-    pub fn set_column_width(&mut self, column: u16, width: u16) -> PyResult<()> {
+    pub fn set_column_width(&mut self, column: ColNum, width: f64) -> PyResult<()> {
         let worksheet = self
             .workbook
             .worksheet_from_index(self.active_worksheet_index)
@@ -421,7 +421,7 @@ impl ExcelWorkbook {
     ///
     ///     workbook.save("example.xlsx")
     /// ```
-    pub fn freeze_panes(&mut self, row: u32, column: u16) -> PyResult<()> {
+    pub fn freeze_panes(&mut self, row: RowNum, column: ColNum) -> PyResult<()> {
         let worksheet = self
             .workbook
             .worksheet_from_index(self.active_worksheet_index)

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -82,10 +82,16 @@ impl ExcelWorkbook {
         let worksheet = self
             .workbook
             .worksheet_from_index(self.active_worksheet_index).unwrap();
-        let format = format::create_format(format_option.unwrap());
-        worksheet
-            .write_number_with_format(row, column, value, &format)
-            .unwrap();
+        if format_option.is_none() {
+            worksheet
+                .write_number(row, column, value)
+                .unwrap();
+        } else {
+            let format = format::create_format(format_option.unwrap());
+            worksheet
+                .write_number_with_format(row, column, value, &format)
+                .unwrap();
+        }
     }
 
     #[pyo3(signature = (start_row, start_column, end_row, end_column, format_option=None))]

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -319,22 +319,11 @@ impl ExcelWorkbook {
         format_option: Option<ExcelFormat>,
     ) -> PyResult<()> {
         if let Some(value) = value {
-            let worksheet = self
-                .workbook
-                .worksheet_from_index(self.active_worksheet_index)
+            // Prevent using moved value
+            let cloned_format_option = format_option.clone();
+            self.merge_range(start_row, start_column, end_row, end_column, format_option)
                 .unwrap();
-
-            if format_option.is_none() {
-                worksheet
-                    .merge_range(
-                        start_row,
-                        start_column,
-                        end_row,
-                        end_column,
-                        "",
-                        &Format::new(),
-                    )
-                    .unwrap();
+            if cloned_format_option.is_none() {
                 self.write(
                     start_row,
                     start_column,
@@ -342,16 +331,10 @@ impl ExcelWorkbook {
                     override_true_value,
                     override_false_value,
                     override_value,
-                    format_option,
+                    cloned_format_option,
                 )
                 .unwrap();
             } else {
-                let cloned_format_option = format_option.clone();
-
-                let format = format::create_format(format_option.unwrap());
-                worksheet
-                    .merge_range(start_row, start_column, end_row, end_column, "", &format)
-                    .unwrap();
                 self.write(
                     start_row,
                     start_column,

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -124,9 +124,9 @@ impl ExcelWorkbook {
     ///     // Write a boolean
     ///     workbook.write(1, 0, True, "Yes", "No")
     ///     // Write an integer
-    ///     workbook.write(2, 0, 42, format_option=ExcelFormat(number_format="#,##0"))
+    ///     workbook.write(2, 0, 42, format_option=ExcelFormat(num_format="#,##0"))
     ///     // Write a float
-    ///     workbook.write(3, 0, 3.14, format_option=ExcelFormat(number_format="#,##0.00"))
+    ///     workbook.write(3, 0, 3.14, format_option=ExcelFormat(num_format="#,##0.00"))
     ///     // Write None
     ///     workbook.write(4, 0, None, override_value="Empty")
     ///     
@@ -223,8 +223,7 @@ impl ExcelWorkbook {
 
     #[pyo3(signature = (start_row, start_column, end_row, end_column, format_option=None))]
     /// Worksheet handler for merging a range of cells. This will not do any
-    /// writing to the cell values. To write values, use either
-    /// `write_string_and_merge_range` or `write_number_and_merge_range`.
+    /// writing to the cell values. To write values, use `write_and_merge_range`.
     ///
     /// ## Parameters
     /// - `start_row`: The start row index of the range

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -293,7 +293,7 @@ impl ExcelWorkbook {
         Ok(())
     }
 
-    #[pyo3(signature = (row, column, value, override_value=None, format_option=None))]
+    #[pyo3(signature = (row, column, value, override_true=None, override_false=None, format_option=None))]
     /// Worksheet handler for writing boolean values. By default, values
     /// are written as `True` or `False`. To specify an override string value
     /// to replace the boolean values, use the `override_value` field.
@@ -302,7 +302,8 @@ impl ExcelWorkbook {
     /// - `row`: The row index of the cell
     /// - `column`: The column index of the cell
     /// - `value`: The boolean value to write
-    /// - `override_value`: The string value to override inplace of `True` or `False` _(optional)_
+    /// - `override_true`: The string value to override `True` value _(optional)_
+    /// - `override_false`: The string value to override `False` value _(optional)_
     /// - `format_option`: The format of the cell _(optional)_
     ///
     /// ## Examples
@@ -314,12 +315,12 @@ impl ExcelWorkbook {
     ///     workbook = ExcelWorkbook()
     ///     workbook.add_worksheet()
     ///     
-    ///     // This will be written to cell as True
+    ///     // This will be written to cell as "TRUE"
     ///     workbook.write_boolean(0, 0, True)
-    ///     // This will be written to cell as False
+    ///     // This will be written to cell as "FALSE"
     ///     workbook.write_boolean(0, 1, False)
-    ///     // This will be written to cell as override value
-    ///     workbook.write_boolean(0, 2, False, "No")
+    ///     // This will be written to cell as "No"
+    ///     workbook.write_boolean(0, 2, False, "Yes", "No")
     ///
     ///     workbook.save("example.xlsx")
     /// ```
@@ -328,13 +329,15 @@ impl ExcelWorkbook {
         row: u32,
         column: u16,
         value: bool,
-        override_value: Option<&str>,
+        override_true: Option<&str>,
+        override_false: Option<&str>,
         format_option: Option<ExcelFormat>,
     ) -> PyResult<()> {
         let worksheet = self
             .workbook
             .worksheet_from_index(self.active_worksheet_index)
             .unwrap();
+        let override_value = if value { override_true } else { override_false };
         if format_option.is_none() {
             match override_value {
                 Some(override_value) => {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,204 @@
+use pyo3::prelude::*;
+use rust_xlsxwriter::{ColNum, RowNum, Worksheet};
+
+use crate::format::{self, ExcelFormat};
+
+/// Worksheet handler for writing string values.
+///
+/// ## Parameters
+/// - `row`: The row index of the cell
+/// - `column`: The column index of the cell
+/// - `value`: The string value to write
+/// - `format_option`: The format of the cell _(optional)_
+///
+/// ## Examples
+/// The following example demonstrates writing a string to a worksheet.
+/// ```
+/// from pyaccelsx import ExcelWorkbook, ExcelFormat
+///
+/// def main():
+///     workbook = ExcelWorkbook()
+///     workbook.add_worksheet()
+///
+///     workbook.write_string(0, 0, "Hello")
+///     format_option = ExcelFormat(bold=True)
+///     workbook.write_string(0, 1, "World!", format_option)
+///
+///     workbook.save("example.xlsx")
+/// ```
+pub fn write_string(
+    worksheet: &mut Worksheet,
+    row: RowNum,
+    column: ColNum,
+    value: &str,
+    format_option: Option<ExcelFormat>,
+) -> PyResult<()> {
+    if format_option.is_none() {
+        worksheet.write_string(row, column, value).unwrap();
+    } else {
+        let format = format::create_format(format_option.unwrap());
+        worksheet
+            .write_string_with_format(row, column, value, &format)
+            .unwrap();
+    }
+    Ok(())
+}
+
+/// Worksheet handler for writing numeric values. By default, values
+/// are passed as a float (`f64`) type. To specify whether to write intenger
+/// or float, use the `format_option` and set the `num_format` field.
+///
+/// ## Parameters
+/// - `row`: The row index of the cell
+/// - `column`: The column index of the cell
+/// - `value`: The numeric value to write
+/// - `format_option`: The format of the cell _(optional)_
+///
+/// ## Examples
+/// The following example demonstrates writing numeric values to a worksheet.
+/// ```
+/// from pyaccelsx import ExcelWorkbook, ExcelFormat
+///
+/// def main():
+///     workbook = ExcelWorkbook()
+///     workbook.add_worksheet()
+///     
+///     // This will be written to cell as float (123445.21)
+///     format_option = ExcelFormat(num_format="#,##0.00")
+///     workbook.write_number(0, 0, 123445.21, format_option)
+///     // This will be written to cell as integer (123,456)
+///     format_option = ExcelFormat(num_format="#,##0")
+///     workbook.write_number(0, 1, 123456, format_option)
+///
+///     workbook.save("example.xlsx")
+/// ```
+pub fn write_number(
+    worksheet: &mut Worksheet,
+    row: RowNum,
+    column: ColNum,
+    value: f64,
+    format_option: Option<ExcelFormat>,
+) -> PyResult<()> {
+    if format_option.is_none() {
+        worksheet.write_number(row, column, value).unwrap();
+    } else {
+        let format = format::create_format(format_option.unwrap());
+        worksheet
+            .write_number_with_format(row, column, value, &format)
+            .unwrap();
+    }
+    Ok(())
+}
+
+/// Worksheet handler for writing boolean values. By default, values
+/// are written as `True` or `False`. To specify an override string value
+/// to replace the boolean values, use the `override_value` field.
+///
+/// ## Parameters
+/// - `row`: The row index of the cell
+/// - `column`: The column index of the cell
+/// - `value`: The boolean value to write
+/// - `override_true_value`: The string value to override `True` value _(optional)_
+/// - `override_false_value`: The string value to override `False` value _(optional)_
+/// - `format_option`: The format of the cell _(optional)_
+///
+/// ## Examples
+/// The following example demonstrates writing boolean values to a worksheet.
+/// ```
+/// from pyaccelsx import ExcelWorkbook
+///
+/// def main():
+///     workbook = ExcelWorkbook()
+///     workbook.add_worksheet()
+///     
+///     // This will be written to cell as "TRUE"
+///     workbook.write_boolean(0, 0, True)
+///     // This will be written to cell as "FALSE"
+///     workbook.write_boolean(0, 1, False)
+///     // This will be written to cell as "No"
+///     workbook.write_boolean(0, 2, False, "Yes", "No")
+///
+///     workbook.save("example.xlsx")
+/// ```
+pub fn write_boolean(
+    worksheet: &mut Worksheet,
+    row: RowNum,
+    column: ColNum,
+    value: bool,
+    override_true_value: Option<String>,
+    override_false_value: Option<String>,
+    format_option: Option<ExcelFormat>,
+) -> PyResult<()> {
+    let override_value = if value {
+        override_true_value
+    } else {
+        override_false_value
+    };
+    if format_option.is_none() {
+        match override_value {
+            Some(override_value) => worksheet.write_string(row, column, override_value).unwrap(),
+            None => worksheet.write_boolean(row, column, value).unwrap(),
+        };
+    } else {
+        let format = format::create_format(format_option.unwrap());
+        match override_value {
+            Some(override_value) => worksheet
+                .write_string_with_format(row, column, override_value, &format)
+                .unwrap(),
+            None => worksheet
+                .write_boolean_with_format(row, column, value, &format)
+                .unwrap(),
+        };
+    }
+    Ok(())
+}
+
+/// Worksheet handler for writing `None` values.
+///
+/// ## Parameters
+/// - `row`: The row index of the cell
+/// - `column`: The column index of the cell
+/// - `override_value`: The string value to write if cell value is None _(optional)_
+/// - `format_option`: The format of the cell _(optional)_
+///
+/// ## Examples
+/// The following example demonstrates writing a `None` value to a worksheet.
+/// ```
+/// from pyaccelsx import ExcelWorkbook, ExcelFormat
+///
+/// def main():
+///     workbook = ExcelWorkbook()
+///     workbook.add_worksheet()
+///
+///     // This will write "N/A" for `None` values
+///     workbook.write_null(0, 0, "N/A")
+///     // This will not perform any write    
+///     workbook.write_null(0, 1)
+///     // This will perform `write_blank`
+///     format_option = ExcelFormat(align="right")
+///     workbook.write_null(row=0, column=2, format_option=format_option)
+///
+///     workbook.save("example.xlsx")
+/// ```
+pub fn write_null(
+    worksheet: &mut Worksheet,
+    row: u32,
+    column: u16,
+    override_value: Option<String>,
+    format_option: Option<ExcelFormat>,
+) -> PyResult<()> {
+    if format_option.is_none() {
+        if let Some(override_value) = override_value {
+            worksheet.write_string(row, column, override_value).unwrap();
+        }
+    } else {
+        let format = format::create_format(format_option.unwrap());
+        match override_value {
+            Some(override_value) => worksheet
+                .write_string_with_format(row, column, override_value, &format)
+                .unwrap(),
+            None => worksheet.write_blank(row, column, &format).unwrap(),
+        };
+    }
+    Ok(())
+}


### PR DESCRIPTION
Summary of changes
- Using index instead of name for referencing the worksheet.
- Use one single function to write for multiple types (`str`, `int`, `float`, `bool`, and `None`)
- Prevent `Format` object from always being created when writing numbers
- Use `write_string` and `write_string_with_format` when writing strings
- Add writer handler for `None` and `boolean` values
- Added format support for
  - Background color
- Added more class and function docs
- Added changelogs