### PR TITLE
Fix release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ This is the changelog/release notes for `Pyaccelsx`.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.2] - 2024-09-10
+
+### Added
+
+- Make `write_string` automatically truncate string if it exceeds the max length allowed in Excel.
+
+### Fixed
+
+- Fixed outdated documentation in README
+- Added missing changes for `row` and `column` types for `write_null`.
+
+### Removed
+
+- Removed misleading documentations.
+
 ## [0.2.1] - 2024-09-08
 
 ### Added
@@ -19,7 +34,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use `write_string` and `write_string_with_format` to write strings.
 - Use index when getting a worksheet instead of name.
 - Make rows and columns to follow the correct type from `rust_xlsxwriter`.
-- Make `write_string` automatically truncate string if it exceeds the max length allowed in Excel.
 - Updated README.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "pyaccelsx"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "pyo3",
  "rust_xlsxwriter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyaccelsx"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Mistakenly update the `v0.2.1` tag. Should have made a v0.2.2 version instead