### PR TITLE
[v0.2.3-dev0] Added a fork version for testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "pyaccelsx"
-version = "0.2.2-dev-large-file"
+version = "0.2.2-dev0"
 dependencies = [
  "pyo3",
  "rust_xlsxwriter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "pyaccelsx"
-version = "0.2.2"
+version = "0.2.2-dev-large-file"
 dependencies = [
  "pyo3",
  "rust_xlsxwriter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "pyaccelsx"
-version = "0.2.2-dev0"
+version = "0.2.3-dev0"
 dependencies = [
  "pyo3",
  "rust_xlsxwriter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,9 +166,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "d30538d42559de6b034bc76fd6dd4c38961b1ee5c6c56e3808c50128fdbc22ce"
 
 [[package]]
 name = "proc-macro2"
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831e8e819a138c36e212f3af3fd9eeffed6bf1510a805af35b0edee5ffa59433"
+checksum = "15ee168e30649f7f234c3d49ef5a7a6cbf5134289bc46c29ff3155fa3221c225"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8730e591b14492a8945cdff32f089250b05f5accecf74aeddf9e8272ce1fa8"
+checksum = "e61cef80755fe9e46bb8a0b8f20752ca7676dcc07a5277d8b7768c6172e529b3"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e97e919d2df92eb88ca80a037969f44e5e70356559654962cbb3316d00300c6"
+checksum = "67ce096073ec5405f5ee2b8b31f03a68e02aa10d5d4f565eca04acc41931fa1c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb57983022ad41f9e683a599f2fd13c3664d7063a3ac5714cae4b7bee7d3f206"
+checksum = "2440c6d12bc8f3ae39f1e775266fa5122fd0c8891ce7520fa6048e683ad3de28"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec480c0c51ddec81019531705acac51bcdbeae563557c982aa8263bb96880372"
+checksum = "1be962f0e06da8f8465729ea2cb71a416d2257dff56cbe40a70d3e62a93ae5d1"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "rust_xlsxwriter"
-version = "0.75.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35629615697da67299569fda0b93e7d79b7bd8cf2cc27b9f526f144e99f5a5af"
+checksum = "c1ba1186cc2b2d0710edd3420d12cbb247c513063d568ca9e5bf52e20068abfb"
 dependencies = [
  "zip",
 ]
@@ -293,18 +293,18 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unindent"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "pyaccelsx"
-version = "0.2.2-dev-large-file"
+version = "0.2.2"
 dependencies = [
  "pyo3",
  "rust_xlsxwriter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,8 +262,7 @@ dependencies = [
 [[package]]
 name = "rust_xlsxwriter"
 version = "0.77.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ba1186cc2b2d0710edd3420d12cbb247c513063d568ca9e5bf52e20068abfb"
+source = "git+https://github.com/stanleysie/rust_xlsxwriter#e6f83a9d7dac0453b972cb1fe0e4b83e69139fdd"
 dependencies = [
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ name = "pyaccelsx"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.22.0"
-rust_xlsxwriter = "0.75.0"
+pyo3 = "0.22.3"
+rust_xlsxwriter = "0.77.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyaccelsx"
-version = "0.2.2-dev-large-file"
+version = "0.2.2-dev0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyaccelsx"
-version = "0.2.2"
+version = "0.2.2-dev-large-file"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyaccelsx"
-version = "0.2.2-dev0"
+version = "0.2.3-dev0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = "0.22.3"
 rust_xlsxwriter = "0.77.0"
+
+[patch.crates-io]
+rust_xlsxwriter = { git = "https://github.com/stanleysie/rust_xlsxwriter" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyaccelsx"
-version = "0.2.2-dev-large-file"
+version = "0.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
-pub mod format;
-pub mod util;
-pub mod workbook;
-pub mod writer;
+mod format;
+mod util;
+mod workbook;
+mod writer;
 
-use format::ExcelFormat;
+pub use crate::format::ExcelFormat;
+pub use crate::workbook::ExcelWorkbook;
+
 use pyo3::prelude::*;
-use workbook::ExcelWorkbook;
 
 /// A Python module implemented in Rust.
 #[pymodule]

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 use rust_xlsxwriter::{ColNum, Format, RowNum, Workbook};
 
-use crate::format::{ExcelFormat, create_format};
+use crate::format::{create_format, ExcelFormat};
 use crate::util::ValueType;
 use crate::writer;
 

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -1,7 +1,7 @@
-use super::format::{self, ExcelFormat};
 use pyo3::prelude::*;
 use rust_xlsxwriter::{ColNum, Format, RowNum, Workbook};
 
+use crate::format::{ExcelFormat, create_format};
 use crate::util::ValueType;
 use crate::writer;
 
@@ -215,7 +215,7 @@ impl ExcelWorkbook {
                 .workbook
                 .worksheet_from_index(self.active_worksheet_index)
                 .unwrap();
-            let format = format::create_format(format_option);
+            let format = create_format(format_option);
             worksheet.write_blank(row, column, &format).unwrap();
         }
         Ok(())
@@ -270,7 +270,7 @@ impl ExcelWorkbook {
                 )
                 .unwrap();
         } else {
-            let format = format::create_format(format_option.unwrap());
+            let format = create_format(format_option.unwrap());
             worksheet
                 .merge_range(start_row, start_column, end_row, end_column, "", &format)
                 .unwrap();

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 use rust_xlsxwriter::{ColNum, RowNum, Worksheet};
 
-use crate::format::{ExcelFormat, create_format};
+use crate::format::{create_format, ExcelFormat};
 
 const MAX_LENGTH: usize = 32767;
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 use rust_xlsxwriter::{ColNum, RowNum, Worksheet};
 
-use crate::format::{self, ExcelFormat};
+use crate::format::{ExcelFormat, create_format};
 
 const MAX_LENGTH: usize = 32767;
 
@@ -20,7 +20,7 @@ pub fn write_string(
     if format_option.is_none() {
         worksheet.write_string(row, column, value).unwrap();
     } else {
-        let format = format::create_format(format_option.unwrap());
+        let format = create_format(format_option.unwrap());
         worksheet
             .write_string_with_format(row, column, value, &format)
             .unwrap();
@@ -38,7 +38,7 @@ pub fn write_number(
     if format_option.is_none() {
         worksheet.write_number(row, column, value).unwrap();
     } else {
-        let format = format::create_format(format_option.unwrap());
+        let format = create_format(format_option.unwrap());
         worksheet
             .write_number_with_format(row, column, value, &format)
             .unwrap();
@@ -66,7 +66,7 @@ pub fn write_boolean(
             None => worksheet.write_boolean(row, column, value).unwrap(),
         };
     } else {
-        let format = format::create_format(format_option.unwrap());
+        let format = create_format(format_option.unwrap());
         match override_value {
             Some(override_value) => worksheet
                 .write_string_with_format(row, column, override_value, &format)
@@ -91,7 +91,7 @@ pub fn write_null(
             worksheet.write_string(row, column, override_value).unwrap();
         }
     } else {
-        let format = format::create_format(format_option.unwrap());
+        let format = create_format(format_option.unwrap());
         match override_value {
             Some(override_value) => worksheet
                 .write_string_with_format(row, column, override_value, &format)


### PR DESCRIPTION
Encountered the following error on `workbook.save` because it fails to unwrap, when trying to export very large file
```
IoError(Custom { kind: Other, error: "Large file option has not been set" })
```

Based on this [discussion]( https://github.com/jmcnamara/rust_xlsxwriter/issues/112), the `large_file` option is disabled by default, so it seems like it's not able to handle saving large data properly at the moment.

This PR contains the test implementation to enable this option by default with a forked `rust_xlsxwriter`.